### PR TITLE
Fix devtool false on production mode

### DIFF
--- a/vue 2/webpack.config.base.js
+++ b/vue 2/webpack.config.base.js
@@ -36,14 +36,13 @@ module.exports = {
   performance: {
     hints: false
   },
-  devtool: '#eval-source-map',
   plugins: [
     new VueLoaderPlugin()
   ]
 }
 
 if (process.env.NODE_ENV === 'production') {
-  module.exports.devtool = '#source-map'
+  module.exports.devtool = false
   // http://vue-loader.vuejs.org/en/workflow/production.html
   module.exports.plugins = (module.exports.plugins || []).concat([
     new webpack.DefinePlugin({
@@ -55,4 +54,6 @@ if (process.env.NODE_ENV === 'production') {
       minimize: true
     })
   ])
+} else {
+  module.exports.devtool = '#eval-source-map'
 }


### PR DESCRIPTION
To reduce the size after build, devtool was set to false to prevent unnecessary map files from being generated in the production environment.